### PR TITLE
Fix idx undefined in component template

### DIFF
--- a/index.html
+++ b/index.html
@@ -321,7 +321,7 @@
         <div id="collapseComponents" class="accordion-collapse collapse" aria-labelledby="headingComponents">
             <div class="accordion-body">
                 <div class="accordion" id="accordionComponents">
-                    <component-form v-for="(comp, cidx) in components" :key="cidx" :comp="comp" :parent="components"></component-form>
+                    <component-form v-for="(comp, cidx) in components" :key="cidx" :comp="comp" :parent="components" :idx="cidx"></component-form>
                     <div class="mt-2">
                         <button class="btn btn-success" type="button" @click="addComponent()" :disabled="components.length >= 40">Add Component</button>
                     </div>
@@ -493,7 +493,7 @@
                         </div>
                     </div>
                     <div v-if="comp.type === 1" class="ms-3">
-                        <component-form v-for="(child, cidx) in comp.components" :key="cidx" :comp="child" :parent="comp.components"></component-form>
+                        <component-form v-for="(child, cidx) in comp.components" :key="cidx" :comp="child" :parent="comp.components" :idx="cidx"></component-form>
                         <button class="btn btn-success btn-sm mt-2" type="button" @click="addChild">Add Child</button>
                     </div>
                     <div class="text-end mt-2">

--- a/index.js
+++ b/index.js
@@ -17,13 +17,10 @@
 
 Vue.component('component-form', {
     template: '#component-form-template',
-    props: ['comp', 'parent'],
+    props: ['comp', 'parent', 'idx'],
     computed: {
         uid() {
             return this._uid;
-        },
-        idx() {
-            return this.parent.indexOf(this.comp);
         }
     },
     methods: {


### PR DESCRIPTION
## Summary
- pass component index from parent to `<component-form>` via `:idx`
- accept `idx` prop in component definition

## Testing
- `node -e "require('./index.js')"` *(fails: Vue is not defined)*

------
https://chatgpt.com/codex/tasks/task_b_6855468a1e088323a4e4c234ba34a1a8